### PR TITLE
feat(GUI): Improving Qt GUI interface

### DIFF
--- a/helper_functions/ik_options.py
+++ b/helper_functions/ik_options.py
@@ -1,0 +1,5 @@
+from inverse_kinematics import FabrikSolver
+
+ik_solvers = {
+    "Fabrik": FabrikSolver
+}

--- a/helper_functions/trajectory_generator_options.py
+++ b/helper_functions/trajectory_generator_options.py
@@ -1,0 +1,5 @@
+from trajectories import QuinticPolynomialTrajectory
+
+trajectory_generators = {
+    "Quintic Polynomial": QuinticPolynomialTrajectory
+}

--- a/inverse_kinematics.py
+++ b/inverse_kinematics.py
@@ -24,6 +24,7 @@ class IKSolverBase(ABC):
     def setup_target(self,
                      target_position: list[float, float],
                      target_orientation: float) -> None:
+        self.solved = False
         self._target_position = list(map(lambda x: x * SCALE_TO_MM, target_position))  # Scaling target from m to mm
         self._target_orientation = wrap_angle_to_pi(target_orientation)
 

--- a/main_gui.py
+++ b/main_gui.py
@@ -6,6 +6,7 @@ import matplotlib
 from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QApplication, QWidget, QLineEdit, QComboBox, QFormLayout, QRadioButton, QVBoxLayout, \
     QPushButton, QMainWindow, QToolBar, QHBoxLayout, QBoxLayout, QDoubleSpinBox, QLabel
+from matplotlib.backend_bases import MouseButton
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 
@@ -272,11 +273,15 @@ class ControlWindow(QWidget):
         self.timer.start()
 
     def on_click(self, event) -> None:
-        self.ik_target_position = [event.xdata/1000.0, event.ydata/1000.0]
-        logger.debug(f"Click event received. Target: {self.ik_target_position}")
-        self.get_traj(move_type=MoveType.CARTESIAN,
-                      target_position=self.ik_target_position,
-                      target_orientation=self.ik_target_orientation)
+        if event.button == MouseButton.LEFT:
+            self.ik_target_position = [event.xdata/1000.0, event.ydata/1000.0]
+            logger.debug(f"Click event received. Target: {self.ik_target_position}")
+            self.get_traj(move_type=MoveType.CARTESIAN,
+                          target_position=self.ik_target_position,
+                          target_orientation=self.ik_target_orientation)
+
+        elif event.button == MouseButton.RIGHT:
+            logger.warning("Context menu to be implemented")  # TODO implement context menu
 
     # TODO implement click and drag
     def _update_canvas_dynamic(self) -> None:

--- a/main_gui.py
+++ b/main_gui.py
@@ -344,7 +344,7 @@ class ControlWindow(QWidget):
             elif field_name == 'Target Orientation':
                 self.ik_target_orientation = field_value
 
-            elif "joint" in field_name:  # Field name = "joint" + idx, for fk target
+            elif "Joint" in field_name:  # Field name = "Joint" + idx, for fk target
                 joint_idx = int(field_name[-1])  # Extracting joint idx
                 self.fk_joint_targets[joint_idx] = field_value
 

--- a/main_gui.py
+++ b/main_gui.py
@@ -113,45 +113,63 @@ class Window(QMainWindow):
             elif isinstance(field_obj, QDoubleSpinBox):
                 field_obj.valueChanged.connect(process_func)
 
-    def _process_field(self, field_id: str, field_obj) -> None:
+            else:
+                logger.warning(f"Unimplemented field: {field_name}")
+
+    def _process_field(self, field_name: str, field_obj) -> None:
         # TODO fix excepts
         if isinstance(field_obj, QLineEdit):
             field_value = field_obj.text()
 
-            if field_id == "link_lengths":
+            if field_name == "link_lengths":
                 try:
                     self.link_lengths = [float(length) for length in field_value.split(",")]
                 except Exception:
                     logger.error("Error processing link lengths", exc_info=True)
                     logger.error("Must be comma separated numbers.")
 
-            elif field_id == "joint_configuration":
+            elif field_name == "joint_configuration":
                 try:
                     self.joint_configuration = [float(angle) for angle in field_value.split(",")]
                 except Exception:
                     logger.error("Error processing joint configuration", exc_info=True)
                     logger.error("Must be comma separated numbers.")
 
+            else:
+                logger.warning(f"Unimplemented QLineEdit: {field_name}. Value: {field_value}")
+
         elif isinstance(field_obj, QDoubleSpinBox):
             field_value = field_obj.value()
 
-            if field_id == "robot_base_radius":
+            if field_name == "robot_base_radius":
                 self.robot_base_radius = field_value
+
+            else:
+                logger.warning(f"Unimplemented QDoubleSpinBox: {field_name}. Value: {field_value}")
 
         elif isinstance(field_obj, QComboBox):
             field_value = field_obj.currentText()
 
-            if field_id == "ik_solver":
+            if field_name == "ik_solver":
                 self.ik_solver = ik_solvers[field_value]()
 
-            elif field_id == "trajectory_generator":
+            elif field_name == "trajectory_generator":
                 self.trajectory_generator = trajectory_generators[field_value]()
+
+            else:
+                logger.warning(f"Unimplemented QComboBox: {field_name}. Value: {field_value}")
 
         elif isinstance(field_obj, QRadioButton):
             field_value = field_obj.isChecked()
 
-            if field_id == "linear_base":
+            if field_name == "linear_base":
                 self.linear_base = field_value
+
+            else:
+                logger.warning(f"Unimplemented QRadioButton: {field_name}. Value: {field_value}")
+
+        else:
+            logger.warning(f"Unimplemented QObject: {field_name}. Type: {type(field_obj)}")
 
     def launch_robot_control(self) -> None:
         robot = Robot(link_lengths=self.link_lengths,
@@ -298,6 +316,9 @@ class ControlWindow(QWidget):
             elif isinstance(field_obj, QDoubleSpinBox):
                 field_obj.valueChanged.connect(process_func)
 
+            else:
+                logger.warning(f"Unimplemented field: {field_name}")
+
         buttons["go_fk"].clicked.connect(lambda: self.get_traj(move_type=MoveType.JOINT,
                                                                target_configuration=self.fk_joint_targets))
 
@@ -318,9 +339,12 @@ class ControlWindow(QWidget):
             elif field_name == 'Target Orientation':
                 self.ik_target_orientation = field_value
 
-            else:  # Field name = "joint" + idx, for fk target
+            elif "joint" in field_name:  # Field name = "joint" + idx, for fk target
                 joint_idx = int(field_name[-1])  # Extracting joint idx
                 self.fk_joint_targets[joint_idx] = field_value
+
+            else:
+                logger.warning(f"Unimplemented QDoubleSpinBox: {field_name}. Value: {field_value}")
 
         elif isinstance(field_obj, QRadioButton):
             field_value = field_obj.isChecked()
@@ -328,6 +352,12 @@ class ControlWindow(QWidget):
             if field_name == 'Mirror':
                 self.mirror = field_value
                 logger.warning("Mirror functionality currently broken")
+
+            else:
+                logger.warning(f"Unimplemented QRadioButton: {field_name}. Value: {field_value}")
+
+        else:
+            logger.warning(f"Unimplemented QObject: {field_name}. Type: {type(field_obj)}")
 
 
 class VisualCanvas(FigureCanvasQTAgg):

--- a/robot.py
+++ b/robot.py
@@ -376,6 +376,10 @@ class Robot:
             reference_angle += target_configuration[link_index]
         self.joint_configuration = calculate_joint_angles(self.vertices, self.linear_base)
 
+        # Resetting the prismatic link
+        if self.linear_base:
+            self.joint_configuration[0] = target_configuration[0] * np.sign(self.vertices["x"][1])
+
         logger.debug(f"Final robot configuration: {self.joint_configuration}")
         logger.debug(f"Final robot vertices: {self.vertices}")
 


### PR DESCRIPTION
Lots of GUI improvements.

**Main changes:**
- Adding options files for implemented IK solvers and trajectory generators. These are used to set up the solvers and generators without having a bunch of if statements e.g. line 155 in main_gui.py. 
- Small fix for the FK and IK interactions, using the IK first and then the FK will cause issues for subsequent IK calls due to the FK resetting the linear base back to zero.
- Fixing IK not resetting solved to False on subsequent IK calls.
- Big changes to QWidgets used for the inputs to the GUI, using QDoubleSpinBox where its appropriate e.g when handling doubles.
- Added better error logging for processing and connecting signals  from QElements. This will help identify errors when adding new elements.