### PR TITLE
fix(GUI): Figure canvas memory issue.

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -481,6 +481,7 @@ class VisualCanvas(FigureCanvasQTAgg):
         """
         self.fig = Figure(figsize=(width, height), dpi=dpi)
         self.axes = self.fig.add_subplot(111)
+        self.parent = parent
         super().__init__(self.fig)
 
 


### PR DESCRIPTION
The Qt figure canvas object was going out of scope and causing a crash. The simple fix was to store a reference to the parent widget inside it.